### PR TITLE
Fix: moved setting of initial workspace to after configs modify taskbar/appbar so the workspace is sized correctly after launch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,10 +127,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             .insert(display.hmonitor, 0);
     }
 
-    info!("Initializing bars");
-
-    change_workspace(1, false).expect("Failed to change workspace to ID@1");
-
     info!("Starting hot reloading of config");
     config::hot_reloading::start();
 
@@ -155,6 +151,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         info!("Registering windows event handler");
         win_event_handler::register()?;
     }
+
+    info!("Initializing bars");
+
+    change_workspace(1, false).expect("Failed to change workspace to ID@1");
 
     info!("Listening for keybindings");
     keybindings::register()?;


### PR DESCRIPTION
I moved the code for the first call to change_workspace when starting up to occur after the config check on appbar/taskbar. What was happening before is that change_workspace calls draw_grid on the first grid, it calculates its height/width and displays and then the config, depending on the user's configuration, hides the taskbar. This causes the grid to not take advantage of the taskbar space if it was configured to be hidden.

Tested this by starting up nog a few times with different configurations of the taskbar/appbar and then managing a window to verify taskbar/appbar space is used if available. 