### PR TITLE
Fix: hidden taskbar space gets used correctly when starting with work…

### DIFF
--- a/src/event_handler/keybinding/toggle_work_mode.rs
+++ b/src/event_handler/keybinding/toggle_work_mode.rs
@@ -4,6 +4,18 @@ use crate::unmanage_everything;
 use crate::win_event_handler;
 use crate::CONFIG;
 use crate::{popup, WORK_MODE};
+use crate::info;
+use crate::workspace::{change_workspace};
+
+pub fn initialize() -> Result<(), Box<dyn std::error::Error>> {
+    if *WORK_MODE.lock().unwrap() {
+        let display_app_bar = CONFIG.lock().unwrap().display_app_bar;
+        let remove_task_bar = CONFIG.lock().unwrap().remove_task_bar;
+        turn_work_mode_on(display_app_bar, remove_task_bar)?;
+    }
+
+    Ok(())
+}
 
 pub fn turn_work_mode_off(
     display_app_bar: bool,
@@ -29,13 +41,21 @@ pub fn turn_work_mode_on(
     display_app_bar: bool,
     remove_task_bar: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    win_event_handler::register()?;
+    if remove_task_bar {
+        info!("Hiding taskbar");
+        task_bar::hide_taskbars();
+    }
     if display_app_bar {
         bar::create::create().expect("Failed to create app bar");
     }
-    if remove_task_bar {
-        task_bar::hide_taskbars();
-    }
+
+    info!("Registering windows event handler");
+    win_event_handler::register()?;
+
+    info!("Initializing bars");
+
+    change_workspace(1, false).expect("Failed to change workspace to ID@1");
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,9 @@ use log::{error, info};
 use std::collections::HashMap;
 use std::sync::Mutex;
 use tile_grid::TileGrid;
+use event_handler::keybinding::toggle_work_mode;
 use winapi::shared::windef::HWND;
-use workspace::{change_workspace, Workspace};
+use workspace::Workspace;
 
 mod bar;
 mod config;
@@ -138,23 +139,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     info!("Initializing workspaces");
     lazy_static::initialize(&WORKSPACES);
 
-    if *WORK_MODE.lock().unwrap() {
-        if CONFIG.lock().unwrap().remove_task_bar {
-            info!("Hiding taskbar");
-            task_bar::hide_taskbars();
-        }
-
-        if CONFIG.lock().unwrap().display_app_bar {
-            bar::create::create()?;
-        }
-
-        info!("Registering windows event handler");
-        win_event_handler::register()?;
-    }
-
-    info!("Initializing bars");
-
-    change_workspace(1, false).expect("Failed to change workspace to ID@1");
+    toggle_work_mode::initialize()?;
 
     info!("Listening for keybindings");
     keybindings::register()?;


### PR DESCRIPTION
…mode disabled

This addresses #152 

The issue here is when starting up with nog's config set to disable work_mode, the code was not messing with the taskbar/appbar but setting up the grid and leaving it in an unusable and invisible state essentially since the appbar is hidden and the keybindings are off. This makes it so that when the user does activate workmode through a keybinding it doesn't re-render the grids correctly to take advantage of any configuration that hides appbar/taskbars. 

To fix this, I did two things

1) reordered the code that toggles workmode on so that it matches what happens when nog starts up.
2) created an "initialize" function in the workmode keybinding handle file and set main to call that instead of having the similar code in two places.

Part of 2 was also to move the "change_workspace(1, false)" call to happen when toggling workmode on (and initialization). A consequence of this is that when toggling workmode on & off, nog will load back and focus on workspace 1 rather than keeping whatever workspace you last had selected. However, since nog unmanages everything when you turn workmode off, the focused workspace seems somewhat arbitrary anyway. In the future, if nog re-manages windows perhaps keeping the state of the last workspace may make more sense.

Tested this by running nog with work_mode disabled/enabled and managing windows/switching workspaces while verifying the hidden taskbar/appbar space is correctly used. Also tested turning workmode on and off and verifying hidden space is correctly used.