### PR TITLE
WIP: Register the appbar with Windows Application Desktop Toolbars API

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use log::info;
 
 use parking_lot::Mutex;
-use winapi::shared::minwindef::LPARAM;
+use winapi::{shared::minwindef::LPARAM, um::winuser::WM_APPCOMMAND, um::winuser::WM_APP, um::shellapi::ABN_FULLSCREENAPP};
 use winapi::shared::minwindef::LRESULT;
 use winapi::shared::minwindef::UINT;
 use winapi::shared::minwindef::WPARAM;
@@ -218,7 +218,17 @@ unsafe extern "system" fn window_cb(
     w_param: WPARAM,
     l_param: LPARAM,
 ) -> LRESULT {
-    if msg == WM_CLOSE {
+    if msg == WM_APP + 1 {
+        if w_param == ABN_FULLSCREENAPP as usize {
+            let is_fullscreen = l_param == 1;
+            if is_fullscreen {
+                visibility::hide();
+            } else {
+                visibility::show();
+            }
+        }
+    }
+    else if msg == WM_CLOSE {
         let mut bars = BARS.lock();
         let idx = bars
             .iter()

--- a/src/bar/close.rs
+++ b/src/bar/close.rs
@@ -1,6 +1,8 @@
 use super::{get_windows, FONT};
 use log::{debug, info};
 use std::ffi::CString;
+use winapi::shared::windef::HWND;
+use winapi::um::shellapi::{SHAppBarMessage, ABM_REMOVE, APPBARDATA};
 use winapi::um::winuser::UnregisterClassA;
 
 pub fn close() {
@@ -8,6 +10,14 @@ pub fn close() {
         info!("Closing appbar");
 
         for window in get_windows() {
+            let mut appbar_data: APPBARDATA = APPBARDATA {
+                cbSize: 4 + 4 + 4 + 4 + 16 + 4,
+                hWnd: window.id as HWND,
+                ..Default::default()
+            };
+
+            SHAppBarMessage(ABM_REMOVE, &mut appbar_data as *mut APPBARDATA);
+
             window.close();
         }
 

--- a/src/bar/create.rs
+++ b/src/bar/create.rs
@@ -1,7 +1,7 @@
 use super::{get_bar_by_hmonitor, get_windows, redraw::redraw, window_cb, Bar, BARS};
 use crate::{event::Event, message_loop, util, CHANNEL, CONFIG, DISPLAYS};
 use log::{debug, error, info};
-use winapi::shared::minwindef::HINSTANCE;
+use winapi::{shared::minwindef::HINSTANCE, um::shellapi::ABM_SETAUTOHIDEBAR, um::winuser::WM_APP};
 use winapi::shared::windef::{HBRUSH, HWND, RECT};
 use winapi::um::shellapi::{
     SHAppBarMessage, ABE_TOP, ABM_NEW, ABM_QUERYPOS, ABM_SETPOS, APPBARDATA,
@@ -88,27 +88,12 @@ pub fn create() -> Result<(), util::WinApiResultError> {
             let mut appbar_data: APPBARDATA = APPBARDATA {
                 cbSize: 4 + 4 + 4 + 4 + 16 + 4,
                 hWnd: window_handle as HWND,
-                uCallbackMessage: window_handle as u32,
+                uCallbackMessage: WM_APP + 1,
                 uEdge: ABE_TOP,
                 ..Default::default()
             };
 
             SHAppBarMessage(ABM_NEW, &mut appbar_data as *mut APPBARDATA);
-
-            GetWindowRect(appbar_data.hWnd as HWND, &mut appbar_data.rc as *mut RECT);
-
-            SHAppBarMessage(ABM_QUERYPOS, &mut appbar_data as *mut APPBARDATA);
-
-            SHAppBarMessage(ABM_SETPOS, &mut appbar_data as *mut APPBARDATA);
-
-            MoveWindow(
-                appbar_data.hWnd as HWND,
-                appbar_data.rc.left,
-                appbar_data.rc.top,
-                appbar_data.rc.right - appbar_data.rc.left,
-                appbar_data.rc.bottom - appbar_data.rc.top,
-                true as i32,
-            );
 
             message_loop::start(|_| true);
         });

--- a/src/bar/create.rs
+++ b/src/bar/create.rs
@@ -1,11 +1,14 @@
-use super::{get_bar_by_hmonitor, redraw::redraw, window_cb, Bar, BARS, get_windows};
-use crate::{message_loop, util, CONFIG, DISPLAYS, CHANNEL, event::Event};
+use super::{get_bar_by_hmonitor, get_windows, redraw::redraw, window_cb, Bar, BARS};
+use crate::{event::Event, message_loop, util, CHANNEL, CONFIG, DISPLAYS};
 use log::{debug, error, info};
-use winapi::shared::windef::HBRUSH;
+use winapi::shared::minwindef::HINSTANCE;
+use winapi::shared::windef::{HBRUSH, HWND, RECT};
+use winapi::um::shellapi::{
+    SHAppBarMessage, ABE_TOP, ABM_NEW, ABM_QUERYPOS, ABM_SETPOS, APPBARDATA,
+};
 use winapi::um::wingdi::CreateSolidBrush;
-use winapi::{
-    shared::minwindef::HINSTANCE,
-    um::winuser::{RegisterClassA, ShowWindow, SW_SHOW, WNDCLASSA},
+use winapi::um::winuser::{
+    GetWindowRect, MoveWindow, RegisterClassA, ShowWindow, SW_SHOW, WNDCLASSA,
 };
 
 pub fn create() -> Result<(), util::WinApiResultError> {
@@ -81,6 +84,31 @@ pub fn create() -> Result<(), util::WinApiResultError> {
 
             ShowWindow(window_handle, SW_SHOW);
             redraw();
+
+            let mut appbar_data: APPBARDATA = APPBARDATA {
+                cbSize: 4 + 4 + 4 + 4 + 16 + 4,
+                hWnd: window_handle as HWND,
+                uCallbackMessage: window_handle as u32,
+                uEdge: ABE_TOP,
+                ..Default::default()
+            };
+
+            SHAppBarMessage(ABM_NEW, &mut appbar_data as *mut APPBARDATA);
+
+            GetWindowRect(appbar_data.hWnd as HWND, &mut appbar_data.rc as *mut RECT);
+
+            SHAppBarMessage(ABM_QUERYPOS, &mut appbar_data as *mut APPBARDATA);
+
+            SHAppBarMessage(ABM_SETPOS, &mut appbar_data as *mut APPBARDATA);
+
+            MoveWindow(
+                appbar_data.hWnd as HWND,
+                appbar_data.rc.left,
+                appbar_data.rc.top,
+                appbar_data.rc.right - appbar_data.rc.left,
+                appbar_data.rc.bottom - appbar_data.rc.top,
+                true as i32,
+            );
 
             message_loop::start(|_| true);
         });

--- a/src/bar/visibility.rs
+++ b/src/bar/visibility.rs
@@ -3,13 +3,17 @@ use super::{get_windows, redraw::redraw};
 #[allow(dead_code)]
 pub fn hide() {
     for window in get_windows() {
-        window.hide();
+        if !window.is_hidden() {
+            window.hide();
+        }
     }
 }
 
 pub fn show() {
     for window in get_windows() {
-        window.show();
+        if window.is_hidden() {
+            window.show();
+        }
     }
 
     redraw();

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,10 +103,12 @@ fn on_quit() -> Result<(), util::WinApiResultError> {
     unmanage_everything()?;
 
     popup::cleanup();
-    let remove_task_bar = {
-        let config = CONFIG.lock();
-        config.remove_task_bar
-    };
+    let display_app_bar = CONFIG.lock().display_app_bar;
+    let remove_task_bar = CONFIG.lock().remove_task_bar;
+
+    if display_app_bar {
+        bar::close::close();
+    }
 
     if remove_task_bar {
         task_bar::show_taskbars();

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,7 +4,7 @@ use crate::{display::Display, CONFIG};
 use gwl_ex_style::GwlExStyle;
 use gwl_style::GwlStyle;
 use log::error;
-use winapi::shared::windef::HWND;
+use winapi::{shared::windef::HWND, um::winuser::IsWindowVisible};
 use winapi::shared::windef::RECT;
 use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::winuser::AdjustWindowRectEx;
@@ -142,6 +142,11 @@ impl Window {
     pub fn hide(&self) {
         unsafe {
             ShowWindow(self.id as HWND, SW_HIDE);
+        }
+    }
+    pub fn is_hidden(&self) -> bool {
+        unsafe {
+            IsWindowVisible(self.id as HWND) == 0
         }
     }
     pub fn calculate_window_rect(


### PR DESCRIPTION
This pull request is an attempt to do what I suggest in #116 to allow for the appbar to be hidden automatically when ever full screen content is displayed on a monitor.

By registering the appbar with Windows not only does it allow for the full screen content to go above the appbar, but Windows will ensure that the space is reserved for Nog only. In the current build a window can technically go under the appbar, this prevents that and will push the window to be below the appbar even if it is not being managed by Nog.

The problem however with this branch is I can seem to figure out how to move the appbar into the space the is reserved by Windows for the appbar. As you can see in this screenshot even though I have set the handle properly Windows is pushing the appbar down out of the reserved space.

![application_desktop_toolbar](https://user-images.githubusercontent.com/13246774/93132742-2db30d80-f6a4-11ea-8efc-477edde439c0.png)

I have tried so many things, but can't seem to get the Nog appbar to be pushed into the reserved space. Maybe I am not using the correct handle or am missing something obvious, but figured @TimUntersberger could take a lock at it.

Additionally, when Nog closes the appbar I ensured that the message to unregister the appbar is sent to Windows this works as expected. In my testing I noticed that in the current build when Nog receives the Exit event the appbars weren't be closed in the on_quit() function so I had to add that otherwise Windows would never unregister the appbar from its internal list.
