### PR TITLE
Only hide appbar on monitor that is displaying fullscreen content

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -220,12 +220,7 @@ unsafe extern "system" fn window_cb(
 ) -> LRESULT {
     if msg == WM_APP + 1 {
         if w_param == ABN_FULLSCREENAPP as usize {
-            let is_fullscreen = l_param == 1;
-            if is_fullscreen {
-                visibility::hide();
-            } else {
-                visibility::show();
-            }
+            visibility::toggle_by_hwnd(hwnd as i32);
         }
     }
     else if msg == WM_CLOSE {

--- a/src/bar/visibility.rs
+++ b/src/bar/visibility.rs
@@ -1,4 +1,4 @@
-use super::{get_windows, redraw::redraw};
+use super::{get_windows, get_bar_by_hwnd, redraw::redraw};
 
 #[allow(dead_code)]
 pub fn hide() {
@@ -17,4 +17,15 @@ pub fn show() {
     }
 
     redraw();
+}
+
+pub fn toggle_by_hwnd(hwnd: i32) {
+    let bar = get_bar_by_hwnd(hwnd).unwrap();
+    match bar.window.is_hidden() {
+        false => bar.window.hide(),
+        true => {
+            bar.window.show();
+            redraw();
+        }
+    }
 }


### PR DESCRIPTION
I noticed that in the current implementation when the ABN_FULLSCREENAPP  message is received it hides all appbars in a multi monitor setup. 

I created a function to toggle a specific appbar using HWND to be the opposite of its current state. 