### PR TITLE
Fix: wrapped set_env with disabling of command processing and updated…

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         rust-version: nightly
     - uses: actions/checkout@v2
-    - uses: nelonoel/branch-name@v1
+    - uses: nelonoel/branch-name@v1.0.1
     - uses: actions/cache@v2
       with:
         path: |
@@ -24,7 +24,12 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Set Env
-      run: echo "::set-env name=COMMIT_HASH::$(git rev-parse --short HEAD)"
+      run: |
+        # disable command workflow processing
+        echo "::stop-commands::pause-logging"
+        echo "::set-env name=COMMIT_HASH::$(git rev-parse --short HEAD)"
+        # enable command workflow processing
+        echo "::pause-logging::"
     - name: Build
       run: cargo build --release
       env:


### PR DESCRIPTION
This addresses #194 

I updated nelonoel/branch-name to v1.0.1 as per the recommendation of the repo [here](https://github.com/nelonoel/branch-name/issues/6)

The other change I made was wrapping the call to set_env in the Set Env section of the auto_release.yml with commands to stop/start workflow commands as recommended [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). However, I tried a few times to use the example there

`        echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"`

where it hashes this github-supplied token that changes on every build for the starting/stopping keyword, but it kept tripping up saying that I had a missing " somewhere. I couldn't get it to work on my fork. But, the example [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands) just uses a string "pause-logging" which worked for me. 

I might not have time to look further into this this weekend, but figured this could resolve the issue now to get the builds up and then it could be changed to use the token if necessary.