### PR TITLE
[RDY] Feat: added to_string/from_string to tilegrid

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use std::cmp::Ordering;
 use task_bar::{Taskbar, TaskbarPosition};
+use log::error;
 
 #[derive(Default, Debug, Clone)]
 pub struct Display {
@@ -224,10 +225,13 @@ pub fn init(config: &Config) -> Vec<Display> {
         Store::save(i, grid.to_string());
 
         if config.remove_title_bar {
-            grid.modify_windows(|window| {
-                window.remove_title_bar(config.use_border)?;
-                Ok(())
-            });
+            match grid.modify_windows(|window| {
+                      window.remove_title_bar(config.use_border)?;
+                      Ok(())
+                  }) {
+                Err(e) => error!("Error while removing title bar {:?}", e),
+                _ => ()
+            }
         }
 
         if let Some(d) = displays.get_mut((monitor - 1) as usize) {

--- a/src/display.rs
+++ b/src/display.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use std::cmp::Ordering;
 use task_bar::{Taskbar, TaskbarPosition};
-use log::error;
 
 #[derive(Default, Debug, Clone)]
 pub struct Display {
@@ -211,7 +210,6 @@ pub fn init(config: &Config) -> Vec<Display> {
         ordering
     });
 
-    let mut stored_grids: Vec<String> = Store::load().into_iter().rev().collect();
     for i in 1..11 {
         let monitor = config
             .workspace_settings
@@ -220,19 +218,7 @@ pub fn init(config: &Config) -> Vec<Display> {
             .map(|s| s.monitor)
             .unwrap_or(-1);
 
-        let mut grid = TileGrid::new(i, renderer::NativeRenderer);
-        grid.from_string(stored_grids.pop().unwrap_or("".into()));
-        Store::save(i, grid.to_string());
-
-        if config.remove_title_bar {
-            match grid.modify_windows(|window| {
-                      window.remove_title_bar(config.use_border)?;
-                      Ok(())
-                  }) {
-                Err(e) => error!("Error while removing title bar {:?}", e),
-                _ => ()
-            }
-        }
+        let grid = TileGrid::new(i, renderer::NativeRenderer);
 
         if let Some(d) = displays.get_mut((monitor - 1) as usize) {
             d.grids.push(grid);

--- a/src/event_handler/keybinding.rs
+++ b/src/event_handler/keybinding.rs
@@ -5,6 +5,7 @@ use crate::{
     event::Event,
     hot_reload::update_config,
     keybindings::{keybinding::Keybinding, keybinding_type::KeybindingType},
+    tile_grid::store::Store,
     system::api,
     system::SystemResult,
     AppState,
@@ -70,11 +71,13 @@ pub fn handle(state_arc: Arc<Mutex<AppState>>, kb: Keybinding) -> SystemResult {
         }
         KeybindingType::MoveToWorkspace(id) => {
             let grid = state.get_current_grid_mut().unwrap();
-            grid.pop()
-                .map(|window| {
-                    state.get_grid_by_id_mut(id).unwrap().push(window);
-                    state.change_workspace(id, false);
-                });
+            let popped_window = grid.pop();
+            Store::save(grid.id, grid.to_string()); // save modification
+
+            popped_window.map(|window| {
+                state.get_grid_by_id_mut(id).unwrap().push(window);
+                state.change_workspace(id, false);
+            });
         }
         KeybindingType::ChangeWorkspace(id) => state.change_workspace(id, false),
         KeybindingType::ToggleFloatingMode => toggle_floating_mode::handle(&mut state)?,

--- a/src/event_handler/keybinding/toggle_floating_mode.rs
+++ b/src/event_handler/keybinding/toggle_floating_mode.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use log::{debug,error};
 
 use crate::{
     event::Event, system::NativeWindow, system::SystemResult,
@@ -15,7 +15,10 @@ pub fn handle(state: &mut AppState) -> SystemResult {
         .and_then(|g| g.remove_by_window_id(window.id).map(|t| (g.id, t)))
         .map(|(id, mut window)| {
             debug!("Unmanaging window '{}' | {}", window.title, window.id);
-            window.cleanup();
+            match window.cleanup() {
+                Err(e) => error!("Error cleaning up window {} {:?}", window.id, e),
+                _ => ()
+            }
 
             id
         });

--- a/src/event_handler/keybinding/toggle_floating_mode.rs
+++ b/src/event_handler/keybinding/toggle_floating_mode.rs
@@ -33,30 +33,6 @@ pub fn handle(state: &mut AppState) -> SystemResult {
             }))
             .expect("Failed to send WinEvent");
     }
-    // if let Some((grid, _)) =  {
-    //     let mut tile = grid.close_tile_by_window_id(window.id).unwrap();
-
-    //     tile.window.cleanup();
-
-    //     let display = state.get_current_display();
-
-    //     debug!(
-    //         "Unmanaging window '{}' | {}",
-    //         tile.window.title, tile.window.id
-    //     );
-
-    //     grid.draw_grid(display, &state.config);
-    //     display.refresh_grid(&state.config);
-    // } else {
-    //     state
-    //         .event_channel
-    //         .sender
-    //         .clone()
-    //         .send(Event::WinEvent(WinEvent {
-    //             typ: WinEventType::Show(true),
-    //             window,
-    //         }))?;
-    // }
 
     Ok(())
 }

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, thread, time::Duration};
 
 use parking_lot::Mutex;
 
-use crate::{bar, config::Config, startup, system::SystemResult, task_bar, AppState, keybindings::KbManager};
+use crate::{bar, config::Config, startup, system::SystemResult, AppState, keybindings::KbManager};
 
 pub fn update_config(state_arc: Arc<Mutex<AppState>>, new_config: Config) -> SystemResult {
     let mut state = state_arc.lock();

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ impl AppState {
     pub fn init(&mut self, config: Config) {
         self.config = config;
         self.work_mode = self.config.work_mode;
-        self.displays = display::init(&self.config);
+        self.displays = time!("initializing displays", display::init(&self.config));
         self.keybindings_manager = KbManager::new(self.config.keybindings.clone());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ impl Default for AppState {
         let config = Config::default();
         Self {
             work_mode: true,
-            displays: time!("initializing displays", display::init(&config)),
+            displays: Vec::<Display>::new(),
             keybindings_manager: KbManager::new(config.keybindings.clone()),
             event_channel: EventChannel::default(),
             additonal_rules: Vec::new(),

--- a/src/system/win.rs
+++ b/src/system/win.rs
@@ -222,6 +222,9 @@ impl Window {
             nullable_to_result(GetWindowRect(self.id.into(), &mut temp)).map(|_| temp.into())
         }
     }
+    pub fn is_window(&self) -> bool {
+        unsafe { IsWindow(self.id.into()) != 0 }
+    }
     pub fn reset_style(&mut self) {
         self.style = self.original_style;
     }

--- a/src/tile_grid.rs
+++ b/src/tile_grid.rs
@@ -10,7 +10,7 @@ use crate::{
     system::WindowId,
     tile_grid::{
         text_renderer::TextRenderer, node::Node, node::NodeInfo, 
-        graph_wrapper::GraphWrapper, tile_render_info::TileRenderInfo,
+        graph_wrapper::GraphWrapper, tile_render_info::TileRenderInfo
     },
 };
 use std::cmp;
@@ -935,8 +935,8 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
                 Node::Row(info) => { self.graph.swap_node(node_id, Node::column(info.order, info.size)); },
                 _ => ()
             }
-         }
-     }
+        }
+    }
     /// Iterates nodes in tile grid and removes any that are no longer valid windows
     pub fn remove_empty_tiles(&mut self) {
         for node_id in self.graph.nodes() {
@@ -983,7 +983,11 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
         if target.len() == 0 { return; }
 
         self.inner_from_string(&target[..], None);
-        self.remove_empty_tiles();
+
+        #[cfg(not(test))] // TODO: Need to refactor Window to be able to fake calls in unit tests
+        {
+            self.remove_empty_tiles();
+        }
     }
     fn inner_from_string(&mut self, target: &str, parent_id: Option<usize>) -> usize {
         // intended to get the matching brace when nested children occur [ [ [ ] ] ]

--- a/src/tile_grid.rs
+++ b/src/tile_grid.rs
@@ -930,6 +930,15 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
                 Node::Row(info) => { self.graph.swap_node(node_id, Node::column(info.order, info.size)); },
                 _ => ()
             }
+         }
+     }
+    /// Iterates nodes in tile grid and removes any that are no longer valid windows
+    pub fn remove_empty_tiles(&mut self) {
+        for node_id in self.graph.nodes() {
+            if self.graph.node(node_id).is_tile() && !self.graph.node(node_id).get_window().is_window() {
+                self.focused_id = Some(node_id);
+                self.pop();
+            }
         }
     }
     /// Returns a stringified version of the grid that follows this format:

--- a/src/tile_grid.rs
+++ b/src/tile_grid.rs
@@ -11,7 +11,6 @@ use crate::{
     tile_grid::{
         text_renderer::TextRenderer, node::Node, node::NodeInfo, 
         graph_wrapper::GraphWrapper, tile_render_info::TileRenderInfo,
-        store::Store
     },
 };
 use std::cmp;
@@ -484,7 +483,8 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
     }
     pub fn close_focused(&mut self) -> Option<NativeWindow> {
         if let Some(focused_node) = self.focused_id.map(|id| self.graph.node(id)) {
-            self.remove_by_window_id(focused_node.get_window().id);
+            let window_id = focused_node.get_window().id;
+            self.remove_by_window_id(window_id);
         }
 
         None

--- a/src/tile_grid/node.rs
+++ b/src/tile_grid/node.rs
@@ -117,4 +117,12 @@ impl Node {
             _ => panic!("Attempt to take window of non-Tile node")
         }
     }
+
+    pub fn to_string(&self) -> String {
+        match self {
+            Node::Column(info) => format!("c{}|{}", info.order, info.size),
+            Node::Row(info) => format!("r{}|{}", info.order, info.size),
+            Node::Tile((info, window)) => format!("t{}|{}|{}", info.order, info.size, window.id),
+        }
+    }
 }

--- a/src/tile_grid/store.rs
+++ b/src/tile_grid/store.rs
@@ -1,8 +1,6 @@
 use std::{fs,path::PathBuf};
 use log::{info,error};
 
-// TODO: need to hide tiles after loading them so they aren't visible if user is on an empty workspace (like workspace 1 when nog loads)
-
 const TEMPLATE: &'static str = "\n\n\n\n\n\n\n\n\n\n"; // TODO: check for OS compatability? 
 pub struct Store { }
 
@@ -15,7 +13,7 @@ impl Store {
             path = dirs::config_dir().expect("Failed to get config directory");
 
             path.push("nog");
-            path.push("grid.nog");
+            path.push("workspaces.grid");
         }
 
         path

--- a/src/tile_grid/store.rs
+++ b/src/tile_grid/store.rs
@@ -1,0 +1,43 @@
+use std::{fs,path::PathBuf};
+use log::{info};
+
+// TODO: need to hide tiles after loading them so they aren't visible if user is on an empty workspace (like workspace 1 when nog loads)
+
+const TEMPLATE: &'static str = "\n\n\n\n\n\n\n\n\n\n"; // TODO: check for OS compatability? 
+pub struct Store { }
+
+impl Store {
+    fn get_path() -> PathBuf {
+        #[allow(unused_mut)]
+        let mut path: PathBuf = dirs::config_dir().expect("Failed to get config directory");
+        path.push("nog");
+        path.push("grid.nog");
+
+        path
+    }
+    pub fn save(id: i32, grid: String) -> std::io::Result<()> {
+        info!("Saving {} {}", id, grid);
+        let file = match fs::read_to_string(Store::get_path()) {
+                       Ok(f) => f,
+                       Err(_) => TEMPLATE.into()
+                   };
+        let file: String = file.split("\n")
+                               .into_iter()
+                               .enumerate()
+                               .map(|(i, value)| if i + 1 == (id as usize) { &grid } else { value })
+                               .collect::<Vec::<_>>()
+                               .join("\n");
+
+        fs::write(Store::get_path(), file)?;
+
+        Ok(())
+    }
+    pub fn load() -> Vec<String> {
+        match fs::read_to_string(Store::get_path()) {
+            Ok(f) => f,
+            Err(_) => TEMPLATE.into()
+        }.split("\n")
+         .map(|x| x.to_string())
+         .collect()
+    }
+}

--- a/src/tile_grid/store.rs
+++ b/src/tile_grid/store.rs
@@ -1,5 +1,5 @@
 use std::{fs,path::PathBuf};
-use log::{info};
+use log::{info,error};
 
 // TODO: need to hide tiles after loading them so they aren't visible if user is on an empty workspace (like workspace 1 when nog loads)
 
@@ -9,13 +9,18 @@ pub struct Store { }
 impl Store {
     fn get_path() -> PathBuf {
         #[allow(unused_mut)]
-        let mut path: PathBuf = dirs::config_dir().expect("Failed to get config directory");
-        path.push("nog");
-        path.push("grid.nog");
+        let mut path: PathBuf = ["./log"].iter().collect();
+        #[cfg(not(debug_assertions))]
+        {
+            path = dirs::config_dir().expect("Failed to get config directory");
+
+            path.push("nog");
+            path.push("grid.nog");
+        }
 
         path
     }
-    pub fn save(id: i32, grid: String) -> std::io::Result<()> {
+    pub fn save(id: i32, grid: String) {
         info!("Saving {} {}", id, grid);
         let file = match fs::read_to_string(Store::get_path()) {
                        Ok(f) => f,
@@ -28,9 +33,10 @@ impl Store {
                                .collect::<Vec::<_>>()
                                .join("\n");
 
-        fs::write(Store::get_path(), file)?;
-
-        Ok(())
+        match fs::write(Store::get_path(), file) {
+            Err(e) => error!("Error storing grid {:?}", e),
+            _ => ()
+        }
     }
     pub fn load() -> Vec<String> {
         match fs::read_to_string(Store::get_path()) {

--- a/src/tile_grid/tests.rs
+++ b/src/tile_grid/tests.rs
@@ -1009,6 +1009,140 @@ fn swap_columns_and_rows_large_graph() {
     assert_eq!(12, node_12);
 }
 
+#[test]
+fn to_string_columns() {
+    // testing just one tile
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "p");
+    assert_eq!("t0|120|1", tile_grid.to_string());
+
+    // testing two tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "p,p");
+    assert_eq!("c0|120[t0|60|1,t1|60|2]", tile_grid.to_string());
+
+    // testing three tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "p,p,p");
+    assert_eq!("c0|120[t0|40|1,t1|40|2,t2|40|3]", tile_grid.to_string());
+
+    // testing four tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "p,p,p,p");
+    assert_eq!("c0|120[t0|30|1,t1|30|2,t2|30|3,t3|30|4]", tile_grid.to_string());
+}
+
+#[test]
+fn to_string_rows() {
+    // testing just one tile
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "axh,p");
+    assert_eq!("t0|120|1", tile_grid.to_string());
+
+    // testing two tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "axh,p,p");
+    assert_eq!("r0|120[t0|60|1,t1|60|2]", tile_grid.to_string());
+
+    // testing three tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "axh,p,p,p");
+    assert_eq!("r0|120[t0|40|1,t1|40|2,t2|40|3]", tile_grid.to_string());
+
+    // testing four tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "axh,p,p,p,p");
+    assert_eq!("r0|120[t0|30|1,t1|30|2,t2|30|3,t3|30|4]", tile_grid.to_string());
+}
+
+#[test]
+fn to_string_children() {
+    /*
+            c
+           / \
+          t0  r
+            / | \
+          t1 t2 t3
+    */
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, "p,p,axh,p,p");
+    assert_eq!("c0|120[t0|60|1,r1|60[t0|40|2,t1|40|3,t2|40|4]]", tile_grid.to_string());
+}
+
+
+#[test]
+fn to_string_large_layout() {
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    perform_actions(&mut tile_grid, LARGE_LAYOUT);
+    assert_eq!("c0|120[t0|60|1,r1|60[t0|24|2,t1|24|3,c2|24[t0|24|6,t1|24|7,r2|24[t0|40|10,t1|40|12,t2|40|11],t3|24|9,t4|24|8],t3|24|5,t4|24|4]]", tile_grid.to_string());
+}
+
+#[test]
+fn from_string_columns() {
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("t0|120|1".into());
+    assert_eq!("t0|120|1", tile_grid.to_string());
+
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("c0|120[t0|60|1,t1|60|2]".into());
+    assert_eq!("c0|120[t0|60|1,t1|60|2]", tile_grid.to_string());
+
+    // testing three tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("c0|120[t0|40|1,t1|40|2,t2|40|3]".into());
+    assert_eq!("c0|120[t0|40|1,t1|40|2,t2|40|3]", tile_grid.to_string());
+
+    // testing four tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("c0|120[t0|30|1,t1|30|2,t2|30|3,t3|30|4]".into());
+    assert_eq!("c0|120[t0|30|1,t1|30|2,t2|30|3,t3|30|4]", tile_grid.to_string());
+}
+
+#[test]
+fn from_string_rows() {
+    // testing just one tile
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("t0|120|1".into());
+    assert_eq!("t0|120|1", tile_grid.to_string());
+
+    // testing two tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("r0|120[t0|60|1,t1|60|2]".into());
+    assert_eq!("r0|120[t0|60|1,t1|60|2]", tile_grid.to_string());
+
+    // testing three tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("r0|120[t0|40|1,t1|40|2,t2|40|3]".into());
+    assert_eq!("r0|120[t0|40|1,t1|40|2,t2|40|3]", tile_grid.to_string());
+
+    // testing four tiles pushed in
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("r0|120[t0|30|1,t1|30|2,t2|30|3,t3|30|4]".into());
+    assert_eq!("r0|120[t0|30|1,t1|30|2,t2|30|3,t3|30|4]", tile_grid.to_string());
+}
+
+#[test]
+fn from_string_children() {
+    /*
+            c
+           / \
+          t0  r
+            / | \
+          t1 t2 t3
+    */
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string("c0|120[t0|60|1,r1|60[t0|40|2,t1|40|3,t2|40|4]]".into());
+    assert_eq!("c0|120[t0|60|1,r1|60[t0|40|2,t1|40|3,t2|40|4]]", tile_grid.to_string());
+}
+
+#[test]
+fn from_string_large_layout() {
+    let large_layout_string = "c0|120[t0|60|1,r1|60[t0|24|2,t1|24|3,c2|24[t0|24|6,t1|24|7,r2|24[t0|40|10,t1|40|12,t2|40|11],t3|24|9,t4|24|8],t3|24|5,t4|24|4]]";
+    let mut tile_grid = TileGrid::new(0, TestRenderer { } );
+    tile_grid.from_string(large_layout_string.into());
+    assert_eq!(large_layout_string, tile_grid.to_string());
+}
+
 fn print(tile_grid: &TileGrid) {
     let render_infos = tile_grid.get_render_info(127, 90);
     println!("{}", TextRenderer::render(127, 90, render_infos)); 


### PR DESCRIPTION
- [X] Add to_string and from_string to tile grid
- [x] Add prune function "remove_empty_tiles" to iterate tilegrid and remove any tiles whose windows no longer exist
- [x] Setup file that stores grid changes to track current state of grids across workspaces
- [x] Add calls to stringify and update grid file when grids are modified
- [x] Add check on launch of nog to call from_string on workspaces found in the file
- [x] Set toggle work mode to use grid layout store
~~- [ ] Wrap updates to the grid file with a "bounce" function to reduce number of writes while user is doing rapid grid modifications~~ decided this currently isn't necessary
