### PR TITLE
[RDY]: #189 keybindings were being ignored after config changes

### DIFF
--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -14,7 +14,8 @@ pub fn update_config(state_arc: Arc<Mutex<AppState>>, new_config: Config) -> Sys
     state.keybindings_manager.stop();
 
     state.config = new_config;
-    state.keybindings_manager = KbManager::new(state.config.keybindings.clone());
+    let new_keybindings = state.config.keybindings.clone();
+    state.keybindings_manager.update_bindings(new_keybindings);
 
     if work_mode {
         if old_config.remove_task_bar && !state.config.remove_task_bar {


### PR DESCRIPTION
Still testing this, but setting the keybindings_manager to update its vec of keybindings instead of instantiating a new manager in the hot_config reload seems to resolve the issue. I believe this works because it maintains that initial thread running... I think overwriting the manager causes the spawned thread to panic and then cause all keybindings to stop working. To make it work, I had to wrap the keybindings with a mutex and I made the get calls return clones rather than references (because of the arc) but it looks like the keybindings were being cloned anyway afterward so it may not be a significant difference.

This was initially caused by the changes for #185. I verified that fix still works; alt+q still closes the popup that appears if the user's config has an error.

This addresses #189 (and #185)