### PR TITLE
[RDY] Fix: Registering a keybinding used by another application stops all keybinding registration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,7 @@ use event::Event;
 use event::EventChannel;
 use event_handler::keybinding::toggle_work_mode;
 use hot_reload::update_config;
-use keybindings::{
-    key::Key, keybinding::Keybinding, keybinding_type::KeybindingType, modifier::Modifier,
-    KbManager,
-};
+use keybindings::KbManager;
 use log::debug;
 use log::{error, info};
 use parking_lot::{deadlock, Mutex};
@@ -513,13 +510,7 @@ fn main() {
         let config = parse_config(state_arc.clone())
             .map_err(|e| {
                 let state_arc = state_arc.clone();
-                thread::spawn(move || {
-                    Popup::new()
-                        .with_padding(5)
-                        .with_text(&[&e, "", "(Press Alt+Q to close)"])
-                        .create(state_arc)
-                        .unwrap()
-                });
+                Popup::error(e, state_arc);
             })
             .unwrap_or_default();
         state_arc.lock().init(config)

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -3,7 +3,7 @@ use crate::{
     NOG_POPUP_NAME,
 };
 use parking_lot::Mutex;
-use std::{fmt::Debug, sync::Arc, thread::JoinHandle};
+use std::{fmt::Debug, sync::Arc, thread::JoinHandle, thread};
 
 static POPUP: Mutex<Option<Popup>> = Mutex::new(None);
 
@@ -37,6 +37,16 @@ impl Popup {
             text: Vec::new(),
             actions: Vec::new(),
         }
+    }
+
+    pub fn error(msg: String, state_arc: Arc<Mutex<AppState>>) {
+        thread::spawn(move || {
+            Popup::new()
+                .with_padding(5)
+                .with_text(&[&msg, "", "(Press Alt+Q to close)"])
+                .create(state_arc)
+                .unwrap()
+        });
     }
 
     pub fn with_text(mut self, text: &[&str]) -> Self {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -88,6 +88,8 @@ pub enum SystemError {
     GetForegroundWindow(SpecificError),
     #[error("Failed to launch a program")]
     LaunchProgram(String),
+    #[error("Failed to register keybinding")]
+    RegisterKeybinding(String),
     #[error("An error that is specific to the platform occured")]
     Native(#[from] SpecificError),
     #[error("An unknown error occured")]

--- a/src/system/win/api.rs
+++ b/src/system/win/api.rs
@@ -172,15 +172,18 @@ pub fn remove_launch_on_startup() {
     }
 }
 
-pub fn register_keybinding(kb: &Keybinding) {
+pub fn register_keybinding(kb: &Keybinding) -> SystemResult {
     unsafe {
-        nullable_to_result(RegisterHotKey(
-            std::ptr::null_mut(),
-            kb.get_id(),
-            kb.modifier.bits(),
-            kb.key as u32,
-        ))
-        .expect("Failed to register keybinding");
+        let result = nullable_to_result(RegisterHotKey(
+                                  std::ptr::null_mut(),
+                                  kb.get_id(),
+                                  kb.modifier.bits(),
+                                  kb.key as u32,
+                              ));
+        match result {
+            Err(_) => Err(SystemError::RegisterKeybinding(format!("{:?}",kb))),
+            _ => Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
This addresses the issue where if a keybinding fails nog stops registering keybindings without notifying the user what's happening, which is what issue #198 is about and I suspect what #190 is as well. This was found by binding Jetbrains Toolbox to launch on a keybinding that is configured in nog and then launching nog after the Toolbox application is already running.

To "fix" this I made nog just show a popup explaining the issue and then letting it continue binding other keybindings that it can. I don't think we can _take_ the keybinding from the other application and even if we could I'm not sure if that's user friendly? Idk, maybe if there's a way it could be configurable.

Here's what I have it display

![popup](https://user-images.githubusercontent.com/1421719/101024948-d86bf700-3542-11eb-9cac-2fcdc590137f.png)
