### PR TITLE
Fix: move_in and move_out re-added

### DIFF
--- a/doc-gen/nogscript/nog/workspace.ns
+++ b/doc-gen/nogscript/nog/workspace.ns
@@ -43,3 +43,20 @@ extern fn swap(direction)
 /// Sets the workspace specific direction in which new windows get ordered
 /// @param direction "Horizontal" | "Vertial"
 extern fn set_split_direction(direction)
+
+/// Moves the current window into the adjacent row/column/window found in the given
+/// direction. If the adjecent item is a row or column, this simply moves the window
+/// to the end of the row or column. If the adjacent item is a window, this introduces
+/// a new column or row container, whichever is the opposite of the current window's
+/// parent, and appends the window and the adjacent window within the new container.
+/// @param direction "Left" | "Right" | "Up" | "Down"
+extern fn move_in(direction)
+
+/// Swaps the position of the current window with the next window in the given direction
+
+/// Moves the current window out of a row/column in the given direction. The behavior 
+/// of this movement is essentially moving the current window so that it is a sibling 
+/// of its parent and introducing a new parent node that is the opposite type of the 
+/// previous parent if necessary.
+/// @param direction "Left" | "Right" | "Up" | "Down"
+extern fn move_out(direction)

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -425,6 +425,34 @@ impl AppState {
         Ok(())
     }
 
+    pub fn move_in(&mut self, direction: Direction) -> SystemResult {
+        let config = self.config.clone();
+        let display = self.get_current_display_mut();
+
+        if let Some(grid) = display.get_focused_grid_mut() {
+            if !config.ignore_fullscreen_actions || !grid.is_fullscreened() {
+                grid.move_focused_in(direction);
+                display.refresh_grid(&config)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn move_out(&mut self, direction: Direction) -> SystemResult {
+        let config = self.config.clone();
+        let display = self.get_current_display_mut();
+
+        if let Some(grid) = display.get_focused_grid_mut() {
+            if !config.ignore_fullscreen_actions || !grid.is_fullscreened() {
+                grid.move_focused_out(direction);
+                display.refresh_grid(&config)?;
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn focus(&mut self, direction: Direction) -> SystemResult {
         let config = self.config.clone();
         let display = self.get_current_display_mut();

--- a/twm/src/nogscript/lib/mod.rs
+++ b/twm/src/nogscript/lib/mod.rs
@@ -142,10 +142,22 @@ pub fn create_root_module(
     });
 
     let state = state_arc.clone();
-    workspace = workspace.function("move_in", move |_, args| Ok(Dynamic::Null));
+    workspace = workspace.function("move_in", move |_, args| {
+        state
+            .lock()
+            .move_in(Direction::from_str(string!(&args[0])?).unwrap());
+
+        Ok(Dynamic::Null)
+    });
 
     let state = state_arc.clone();
-    workspace = workspace.function("move_out", move |_, args| Ok(Dynamic::Null));
+    workspace = workspace.function("move_out", move |_, args| {
+        state
+            .lock()
+            .move_out(Direction::from_str(string!(&args[0])?).unwrap());
+
+        Ok(Dynamic::Null)
+    });
 
     let state = state_arc.clone();
     workspace = workspace.function("focus", move |_, args| {


### PR DESCRIPTION
This is just filling in the bindings for move_in and move_out that got lost in all the changes I think.