### PR TITLE
[RDY] Tiling and Workspace fixes

### DIFF
--- a/doc-gen/nogscript/nog/bar/components.ns
+++ b/doc-gen/nogscript/nog/bar/components.ns
@@ -40,6 +40,12 @@ extern fn active_mode()
 /// @returns BarComponent
 extern fn split_direction(vertical_text, horizontal_text)
 
+/// Renders the indicator value if the current workspace has a fullscreened window.
+///
+/// @param indicator String
+/// @returns BarComponent
+extern fn fullscreen_indicator(indicator)
+
 /// Renders the text.
 ///
 /// @param text String

--- a/doc-gen/nogscript/nog/workspace.ns
+++ b/doc-gen/nogscript/nog/workspace.ns
@@ -6,8 +6,10 @@ extern fn change(id)
 /// @param id Number
 extern fn move_to_monitor(id)
 
-/// Moves the focused workspace to the workspace that has the given index.
-/// The target workspace must be empty.
+/// Moves all windows in the focused workspace to the workspace that has 
+/// the given index while maintaining relative sizes and positions. 
+/// The target workspace must be empty. This allows you to transfer
+/// an entire workspace to an empty workspace of a different number.
 /// @param id Number
 extern fn workspace_to_workspace(id)
 

--- a/doc-gen/nogscript/nog/workspace.ns
+++ b/doc-gen/nogscript/nog/workspace.ns
@@ -6,6 +6,11 @@ extern fn change(id)
 /// @param id Number
 extern fn move_to_monitor(id)
 
+/// Moves the focused workspace to the workspace that has the given index.
+/// The target workspace must be empty.
+/// @param id Number
+extern fn workspace_to_workspace(id)
+
 /// Toggles fullscreen mode
 extern fn toggle_fullscreen()
 

--- a/twm/src/bar/component.rs
+++ b/twm/src/bar/component.rs
@@ -6,6 +6,7 @@ use std::{any::Any, collections::HashMap, fmt::Debug, sync::Arc};
 pub mod active_mode;
 pub mod current_window;
 pub mod date;
+pub mod fullscreen_indicator;
 pub mod padding;
 pub mod split_direction;
 pub mod time;

--- a/twm/src/bar/component/fullscreen_indicator.rs
+++ b/twm/src/bar/component/fullscreen_indicator.rs
@@ -1,0 +1,23 @@
+use super::{AppState, Component, ComponentText};
+use crate::system::DisplayId;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+pub fn create(state_arc: Arc<Mutex<AppState>>, indicator: String) -> Component {
+    Component::new("FullscreenIndicator", move |display_id| {
+        Ok(vec![ComponentText::new().with_display_text(
+            state_arc
+                .lock()
+                .get_display_by_id(display_id)
+                .and_then(|d| d.get_focused_grid())
+                .map(|g| {
+                    if g.is_fullscreened() {
+                        indicator.clone()
+                    } else {
+                        "".into()
+                    }
+                })
+                .unwrap_or("".into()),
+        )])
+    })
+}

--- a/twm/src/bar/component/workspaces.rs
+++ b/twm/src/bar/component/workspaces.rs
@@ -11,10 +11,12 @@ pub fn create(state_arc: Arc<Mutex<AppState>>) -> Component {
         let workspace_settings = state.config.workspace_settings.clone();
         let bar_color = state.config.bar.color;
 
-        Ok(state
-            .get_display_by_id(display_id)
-            .unwrap()
-            .get_active_grids()
+        let mut grids = state.get_display_by_id(display_id)
+                             .unwrap()
+                             .get_active_grids();
+        grids.sort_by_key(|g| g.id);
+
+        Ok(grids
             .iter()
             .map(|grid| {
                 let factor = if light_theme {

--- a/twm/src/bar/component/workspaces.rs
+++ b/twm/src/bar/component/workspaces.rs
@@ -11,9 +11,10 @@ pub fn create(state_arc: Arc<Mutex<AppState>>) -> Component {
         let workspace_settings = state.config.workspace_settings.clone();
         let bar_color = state.config.bar.color;
 
-        let mut grids = state.get_display_by_id(display_id)
-                             .unwrap()
-                             .get_active_grids();
+        let mut grids = state
+            .get_display_by_id(display_id)
+            .unwrap()
+            .get_active_grids();
         grids.sort_by_key(|g| g.id);
 
         Ok(grids

--- a/twm/src/config.rs
+++ b/twm/src/config.rs
@@ -71,7 +71,7 @@ impl Default for Config {
             update_channels: Vec::new(),
             default_update_channel: None,
             update_interval: Duration::from_secs(60 * 60),
-            allow_right_alt: false
+            allow_right_alt: false,
         }
     }
 }

--- a/twm/src/config.rs
+++ b/twm/src/config.rs
@@ -41,6 +41,7 @@ pub struct Config {
     /// contains the metadata for each mode (like an icon)
     /// HashMap<mode, (Option<char>)>
     pub mode_meta: HashMap<String, Option<char>>,
+    pub allow_right_alt: bool,
 }
 
 impl Default for Config {
@@ -70,6 +71,7 @@ impl Default for Config {
             update_channels: Vec::new(),
             default_update_channel: None,
             update_interval: Duration::from_secs(60 * 60),
+            allow_right_alt: false
         }
     }
 }
@@ -104,6 +106,7 @@ impl Config {
             "inner_gap" => self.inner_gap = value.parse().unwrap(),
             "min_width" => self.min_width = value.parse().unwrap(),
             "min_height" => self.min_height = value.parse().unwrap(),
+            "allow_right_alt" => self.allow_right_alt = value.parse().unwrap(),
             _ => todo!("{}", field),
         }
     }
@@ -127,6 +130,7 @@ impl Config {
             "remove_title_bar" => self.remove_title_bar = !self.remove_title_bar,
             "remove_task_bar" => self.remove_task_bar = !self.remove_task_bar,
             "display_app_bar" => self.display_app_bar = !self.display_app_bar,
+            "allow_right_alt" => self.allow_right_alt = !self.allow_right_alt,
             "ignore_fullscreen_actions" => {
                 self.ignore_fullscreen_actions = !self.ignore_fullscreen_actions
             }
@@ -158,6 +162,7 @@ impl Config {
             "remove_task_bar" => config.remove_task_bar = value,
             "ignore_fullscreen_actions" => config.ignore_fullscreen_actions = value,
             "display_app_bar" => config.display_app_bar = value,
+            "allow_right_alt" => config.allow_right_alt = value,
             _ => error!("Attempt to set unknown field: {}", field),
         }
         config

--- a/twm/src/event_handler/winevent/destroy.rs
+++ b/twm/src/event_handler/winevent/destroy.rs
@@ -6,7 +6,7 @@ pub fn handle(
     _grid_id: Option<i32>, // TODO: maybe remove this? IDK
 ) -> SystemResult {
     if let Some(_) = state
-        .find_window(window.id)
+        .find_grid_containing_window(window.id)
         .map(|g| g.remove_by_window_id(window.id))
     {
         state.get_current_display().refresh_grid(&state.config)?;

--- a/twm/src/event_handler/winevent/focus_change.rs
+++ b/twm/src/event_handler/winevent/focus_change.rs
@@ -1,7 +1,7 @@
 use crate::{system::NativeWindow, system::SystemResult, AppState};
 
 pub fn handle(state: &mut AppState, window: NativeWindow) -> SystemResult {
-    if let Some(g) = state.find_window(window.id) {
+    if let Some(g) = state.find_grid_containing_window(window.id) {
         g.focus_tile_by_window_id(window.id);
         state.workspace_id = g.id;
     }

--- a/twm/src/hot_reload.rs
+++ b/twm/src/hot_reload.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use parking_lot::Mutex;
+use std::sync::Arc;
 
 use crate::{bar, config::Config, keybindings::KbManager, startup, system::SystemResult, AppState};
 

--- a/twm/src/hot_reload.rs
+++ b/twm/src/hot_reload.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
-
 use parking_lot::Mutex;
 
 use crate::{bar, config::Config, keybindings::KbManager, startup, system::SystemResult, AppState};
 
 pub fn update_config(state_arc: Arc<Mutex<AppState>>, new_config: Config) -> SystemResult {
+    let state = state_arc.lock();
+    state.keybindings_manager.update_configuration(&new_config);
+    drop(state);
+
     let prev_mode = state_arc.lock().keybindings_manager.get_mode();
     state_arc
         .lock()

--- a/twm/src/keybindings.rs
+++ b/twm/src/keybindings.rs
@@ -321,7 +321,10 @@ impl KbManager {
                     };
                 }
 
-                if let Some(kb) = do_loop(&inner.lock()) {
+                let inner_lock = inner.lock();
+                let kb = do_loop(&inner_lock);
+                drop(inner_lock);
+                if let Some(kb) = kb {
                     let work_mode = state.lock().work_mode;
                     if work_mode || kb.always_active {
                         let sender = state.lock().event_channel.sender.clone();

--- a/twm/src/keybindings.rs
+++ b/twm/src/keybindings.rs
@@ -1,4 +1,4 @@
-use crate::{event::Event, popup::Popup, system, system::api, AppState};
+use crate::{event::Event, popup::Popup, system, system::api, AppState, config::Config};
 use key::Key;
 use keybinding::Keybinding;
 use log::{debug, error, info};
@@ -41,12 +41,13 @@ struct KbManagerInner {
     /// Key is mode name and value is the callback id
     pub mode_handlers: HashMap<String, usize>,
     pub keybindings: Vec<Keybinding>,
+    allow_right_alt: bool,
     mode_keybindings: Mutex<HashMap<String, Vec<Keybinding>>>,
     mode: Mutex<Mode>,
 }
 
 impl KbManagerInner {
-    pub fn new(kbs: Vec<Keybinding>, handlers: HashMap<String, usize>) -> Self {
+    pub fn new(kbs: Vec<Keybinding>, handlers: HashMap<String, usize>, allow_right_alt: bool) -> Self {
         Self {
             running: AtomicBool::new(false),
             mode_handlers: handlers,
@@ -54,6 +55,7 @@ impl KbManagerInner {
             mode: Mutex::new(None),
             keybindings: kbs,
             mode_keybindings: Mutex::new(HashMap::new()),
+            allow_right_alt: allow_right_alt
         }
     }
 
@@ -127,10 +129,10 @@ impl Debug for KbManager {
 }
 
 impl KbManager {
-    pub fn new(kbs: Vec<Keybinding>, handlers: HashMap<String, usize>) -> Self {
+    pub fn new(kbs: Vec<Keybinding>, handlers: HashMap<String, usize>, allow_right_alt: bool) -> Self {
         let (sender, receiver) = channel();
         Self {
-            inner: Arc::new(Mutex::new(KbManagerInner::new(kbs, handlers))),
+            inner: Arc::new(Mutex::new(KbManagerInner::new(kbs, handlers, allow_right_alt))),
             sender,
             receiver: Arc::new(Mutex::new(receiver)),
         }
@@ -139,6 +141,9 @@ impl KbManager {
         self.sender
             .send(ChanMessage::ChangeMode(mode.clone()))
             .expect("Failed to change mode of kb manager");
+    }
+    pub fn update_configuration(&self, config: &Config) {
+        self.inner.lock().allow_right_alt = config.allow_right_alt;
     }
     pub fn leave_work_mode(&self) {
         self.sender
@@ -356,11 +361,15 @@ fn do_loop(inner: &KbManagerInner) -> Option<Keybinding> {
         if msg.message != WM_HOTKEY {
             return None;
         }
-        // if the right alt key is down skip the hotkey, because we don't support right alt
-        // keybindings to avoid false positives
-        if unsafe { GetKeyState(VK_RMENU) } & 0b111111110000000 != 0 {
-            return None;
+
+        if !inner.allow_right_alt {
+            // if the right alt key is down skip the hotkey, because we don't support right alt
+            // keybindings to avoid false positives
+            if unsafe { GetKeyState(VK_RMENU) } & 0b111111110000000 != 0 {
+                return None;
+            }
         }
+
         let modifier = Modifier::from_bits((msg.lParam & 0xffff) as u32).unwrap();
 
         if let Some(key) = Key::from_isize(msg.lParam >> 16) {

--- a/twm/src/keybindings.rs
+++ b/twm/src/keybindings.rs
@@ -1,4 +1,4 @@
-use crate::{event::Event, popup::Popup, system, system::api, AppState, config::Config};
+use crate::{config::Config, event::Event, popup::Popup, system, system::api, AppState};
 use key::Key;
 use keybinding::Keybinding;
 use log::{debug, error, info};
@@ -47,7 +47,11 @@ struct KbManagerInner {
 }
 
 impl KbManagerInner {
-    pub fn new(kbs: Vec<Keybinding>, handlers: HashMap<String, usize>, allow_right_alt: bool) -> Self {
+    pub fn new(
+        kbs: Vec<Keybinding>,
+        handlers: HashMap<String, usize>,
+        allow_right_alt: bool,
+    ) -> Self {
         Self {
             running: AtomicBool::new(false),
             mode_handlers: handlers,
@@ -55,7 +59,7 @@ impl KbManagerInner {
             mode: Mutex::new(None),
             keybindings: kbs,
             mode_keybindings: Mutex::new(HashMap::new()),
-            allow_right_alt: allow_right_alt
+            allow_right_alt: allow_right_alt,
         }
     }
 
@@ -129,10 +133,18 @@ impl Debug for KbManager {
 }
 
 impl KbManager {
-    pub fn new(kbs: Vec<Keybinding>, handlers: HashMap<String, usize>, allow_right_alt: bool) -> Self {
+    pub fn new(
+        kbs: Vec<Keybinding>,
+        handlers: HashMap<String, usize>,
+        allow_right_alt: bool,
+    ) -> Self {
         let (sender, receiver) = channel();
         Self {
-            inner: Arc::new(Mutex::new(KbManagerInner::new(kbs, handlers, allow_right_alt))),
+            inner: Arc::new(Mutex::new(KbManagerInner::new(
+                kbs,
+                handlers,
+                allow_right_alt,
+            ))),
             sender,
             receiver: Arc::new(Mutex::new(receiver)),
         }

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -162,6 +162,7 @@ impl Default for AppState {
             keybindings_manager: KbManager::new(
                 config.keybindings.clone(),
                 config.mode_handlers.clone(),
+                config.allow_right_alt,
             ),
             event_channel: EventChannel::default(),
             additonal_rules: Vec::new(),
@@ -180,6 +181,7 @@ impl AppState {
             keybindings_manager: KbManager::new(
                 config.keybindings.clone(),
                 config.mode_handlers.clone(),
+                config.allow_right_alt,
             ),
             event_channel: EventChannel::default(),
             additonal_rules: Vec::new(),
@@ -195,6 +197,7 @@ impl AppState {
         self.keybindings_manager = KbManager::new(
             self.config.keybindings.clone(),
             self.config.mode_handlers.clone(),
+            self.config.allow_right_alt,
         );
     }
 

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -421,8 +421,10 @@ impl AppState {
         let display = self.get_current_display_mut();
 
         if let Some(grid) = display.get_focused_grid_mut() {
-            grid.swap_focused(direction);
-            display.refresh_grid(&config);
+            if !config.ignore_fullscreen_actions || !grid.is_fullscreened() {
+                grid.swap_focused(direction);
+                display.refresh_grid(&config);
+            }
         }
 
         Ok(())
@@ -461,8 +463,10 @@ impl AppState {
         let display = self.get_current_display_mut();
 
         if let Some(grid) = display.get_focused_grid_mut() {
-            grid.focus(direction)?;
-            display.refresh_grid(&config);
+            if !config.ignore_fullscreen_actions || !grid.is_fullscreened() {
+                grid.focus(direction)?;
+                display.refresh_grid(&config);
+            }
         }
 
         Ok(())

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -28,8 +28,8 @@ use std::fs::ReadDir;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
+use std::{mem, thread, time::Duration};
 use std::{process, sync::atomic::AtomicBool, sync::Arc};
-use std::{thread, time::Duration, mem};
 use system::NativeWindow;
 use system::{DisplayId, SystemResult, WinEventListener, WindowId};
 use task_bar::Taskbar;
@@ -236,7 +236,9 @@ impl AppState {
     }
 
     pub fn move_workspace_to_workspace(&mut self, workspace_id: i32) -> SystemResult {
-        let is_empty = self.get_grid_by_id(workspace_id).map_or(false, |g| g.is_empty());
+        let is_empty = self
+            .get_grid_by_id(workspace_id)
+            .map_or(false, |g| g.is_empty());
         let current_id = self.workspace_id.clone();
         let current_grid_exists = self.get_current_grid().is_some();
         if is_empty && current_grid_exists && current_id != workspace_id {

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -1072,11 +1072,14 @@ fn main() {
             continue;
         }
 
-        debug!("deadlock detected");
-        debug!(
-            "backtrace: \n{:?}",
-            deadlocks.first().unwrap().first().unwrap().backtrace()
-        );
+        debug!("{} deadlocks detected", deadlocks.len());
+        for (i, threads) in deadlocks.iter().enumerate() {
+            debug!("Deadlock #{}", i);
+            for t in threads {
+                debug!("Thread Id {:#?}", t.thread_id());
+                debug!("{:#?}", t.backtrace());
+            }
+        }
 
         on_quit(&mut arc.lock()).unwrap();
     });

--- a/twm/src/nogscript/lib/mod.rs
+++ b/twm/src/nogscript/lib/mod.rs
@@ -270,6 +270,15 @@ pub fn create_root_module(
         });
 
         let state = state_arc.clone();
+        m = m.function("fullscreen_indicator", move |_, args| {
+            let indicator = string!(&args[0])?.clone();
+            Ok(
+                component::fullscreen_indicator::create(state.clone(), indicator)
+                    .into_dynamic(state.clone()),
+            )
+        });
+
+        let state = state_arc.clone();
         m = m.function("active_mode", move |_, _| {
             Ok(component::active_mode::create(state.clone()).into_dynamic(state.clone()))
         });

--- a/twm/src/nogscript/lib/mod.rs
+++ b/twm/src/nogscript/lib/mod.rs
@@ -96,6 +96,12 @@ pub fn create_root_module(
     });
 
     let state = state_arc.clone();
+    workspace = workspace.function("workspace_to_workspace", move |_, args| {
+        state.lock().move_workspace_to_workspace(number!(args[0])?);
+        Ok(Dynamic::Null)
+    });
+
+    let state = state_arc.clone();
     workspace = workspace.function("toggle_fullscreen", move |_, args| {
         state.lock().toggle_fullscreen();
         Ok(Dynamic::Null)

--- a/twm/src/tile_grid.rs
+++ b/twm/src/tile_grid.rs
@@ -610,8 +610,6 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
             }
         }
 
-        debug!("{}", self.to_string());
-
         removed_node
     }
     pub fn close_focused(&mut self) -> Option<NativeWindow> {

--- a/twm/src/tile_grid.rs
+++ b/twm/src/tile_grid.rs
@@ -548,19 +548,22 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
                     let (order, size) = self.graph.node(parent_id).get_info();
 
                     if let Some(grand_parent_id) = self.graph.map_to_parent(Some(parent_id)) {
-                        match (self.graph.node(grand_parent_id), self.graph.node(sibling_id)) {
+                        match (
+                            self.graph.node(grand_parent_id),
+                            self.graph.node(sibling_id),
+                        ) {
                             (Node::Column(_), Node::Column(_)) | (Node::Row(_), Node::Row(_)) => {
                                 // here we need to distribute the size of the parent
-                                // across the children of the sibling based on their 
+                                // across the children of the sibling based on their
                                 // existing ratios and then add them to the grand_parent
 
                                 /*
                                     Removing * node (shows size distributions)
                                     c120                c120
-                                    /  \                / | \ 
+                                    /  \                / | \
                                   t60   r60        ->  60 20 20
                                    1   /   \            1  3  4
-                                     *t60  c60             
+                                     *t60  c60
                                        2   / \
                                          t60 t60
                                           3   4
@@ -572,11 +575,14 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
                                 for (i, child_id) in children.iter().rev().enumerate() {
                                     self.graph.disconnect(sibling_id, *child_id);
                                     let child_node = self.graph.node_mut(*child_id);
-                                    let mut new_size = ((child_node.get_size() as f32 / FULL_SIZE as f32) * size as f32) as u32;
+                                    let mut new_size = ((child_node.get_size() as f32
+                                        / FULL_SIZE as f32)
+                                        * size as f32)
+                                        as u32;
 
                                     size_remaining -= new_size;
                                     if number_of_children - 1 == i {
-                                        new_size += size_remaining; 
+                                        new_size += size_remaining;
                                     }
 
                                     child_node.set_info(order, new_size);
@@ -585,7 +591,7 @@ impl<TRenderer: Renderer> TileGrid<TRenderer> {
 
                                 self.reset_order(grand_parent_id);
                                 self.graph.remove_node(sibling_id);
-                            },
+                            }
                             _ => {
                                 self.graph.connect(grand_parent_id, sibling_id);
                                 let keep_node = self.graph.node_mut(sibling_id);

--- a/twm/src/tile_grid/store.rs
+++ b/twm/src/tile_grid/store.rs
@@ -13,9 +13,9 @@ impl Store {
             path = dirs::config_dir().expect("Failed to get config directory");
 
             path.push("nog");
-            path.push("workspaces.grid");
         }
 
+        path.push("workspaces.grid");
         path
     }
     pub fn save(id: i32, grid: String) {

--- a/twm/src/tile_grid/tests.rs
+++ b/twm/src/tile_grid/tests.rs
@@ -1497,6 +1497,78 @@ fn from_string_large_layout() {
     assert_eq!(large_layout_string, tile_grid.to_string());
 }
 
+#[test]
+fn remove_merges_columns() {
+    let mut tile_grid = TileGrid::new(0, TestRenderer {});
+    perform_actions(&mut tile_grid, "p,p,p,fl,axh,p,fu,axv,p,p,fd");
+    perform_actions(&mut tile_grid, "o");
+    /*
+            c____
+           / \   |           c
+          1   r  3     ->    _____
+             / \            /|\ \ \
+            c   4          1 2 5 6 3
+           /|\
+          2 5 6
+    */
+
+    let root = tile_grid.graph.get_root().unwrap();
+    assert!(is_column(&tile_grid, 0), "Expected root node to be column");
+    assert_eq!(
+        5,
+        tile_grid.graph.get_sorted_children(0).len(),
+        "Expected root node to have 4 child tile nodes"
+    );
+
+    let node_1 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[0]);
+    let node_2 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[1]);
+    let node_5 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[2]);
+    let node_6 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[3]);
+    let node_3 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[4]);
+
+    assert_eq!(1, node_1);
+    assert_eq!(2, node_2);
+    assert_eq!(5, node_5);
+    assert_eq!(6, node_6);
+    assert_eq!(3, node_3);
+}
+
+#[test]
+fn remove_merges_rows() {
+    let mut tile_grid = TileGrid::new(0, TestRenderer {});
+    perform_actions(&mut tile_grid, "axh,p,p,p,fu,axv,p,fl,axh,p,p,fr");
+    perform_actions(&mut tile_grid, "o");
+    /*
+            r____
+           / \   |           r
+          1   c  3     ->    _____
+             / \            /|\ \ \
+            r   4          1 2 5 6 3
+           /|\
+          2 5 6
+    */
+
+    let root = tile_grid.graph.get_root().unwrap();
+    assert!(is_row(&tile_grid, 0), "Expected root node to be row");
+    assert_eq!(
+        5,
+        tile_grid.graph.get_sorted_children(0).len(),
+        "Expected root node to have 4 child tile nodes"
+    );
+
+    let node_1 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[0]);
+    let node_2 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[1]);
+    let node_5 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[2]);
+    let node_6 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[3]);
+    let node_3 = get_window_id(&tile_grid, tile_grid.graph.get_sorted_children(0)[4]);
+
+    assert_eq!(1, node_1);
+    assert_eq!(2, node_2);
+    assert_eq!(5, node_5);
+    assert_eq!(6, node_6);
+    assert_eq!(3, node_3);
+}
+
 fn print(tile_grid: &TileGrid) {
     let render_infos = tile_grid.get_render_info(127, 90);
     println!("{}", TextRenderer::render(127, 90, render_infos));


### PR DESCRIPTION
I'll try to keep this original post updated as I get feedback/make changes

This pull request contains the following commits...

1. 05162d2 Fix: workspaces remain ordered by ID when moved across monitor
    I noticed that moving workspaces back and forth across monitors changes the order of them. If you have the following...
      monitor1            monitor2
      1 2 3  7                 5 6
and then moving workspace  5 back to monitor 1 it ends up like this
      monitor1            monitor2
      1 2 3  7 5                6     
This commit keeps the order so it ends up "1 2 3 5 7"

2. 31cc8d2 Feat: made right-alt usage configurable
This is in regards to #210 and just adds a config value to allow usage of the right alt. This is just an initial attempt at it, open to suggestions on a better implementation. Still need to add documentation, but that's dependent on if we decide this is a good idea or not. I'm also not sure exactly where in the doc-gen project that the documentation for config values goes?

3. 30aeb96 Fix: prevent unmanaging windows from inactive workspaces
  This tripped me up a bit a couple times but basically if you switch to another workspace it's possible depending on what windows are currently visible that you still have focus on a window that was on the workspace you just left... and if you toggle to manage/unmanage a window at this point it unmanages the window from the workspace that isn't currently visible. This is more likely to happen when working across multiple monitors and losing track of what window on what workspace you think is focused. 

    This commit just adds some logic to prevent unmanaging the window if it's not on the focused workspace since it's unlikely the user wants that to happen. I also went ahead and renamed a couple functions like find_window and find_grid as their names were incorrect; find_window returns a grid and find_grid returns a display, so I renamed them to find_grid_containing_window and find_grid_display. 

4. a2f31d5 Fix: #211 columns and rows merge
This should be pretty straight forward and is just adding logic for a scenario I documented in #211 that I came across. Also added unit tests for this one.

5.  5d5c617 Feat: Added fullscreen indicator component
This is a quality-of-life improvement for me personally. I often jump back and forth between workspaces and get confused about how I left them. This is to set up a string indicator component that displays in the bar when the current workspace has a window fullscreened. That way I can quickly tell if I have other windows hiding behind the fullscreened one. I added documentation for this one.

6.  1add07e Fix: Re-add missing ignore_fullscreen_actions checks
This is pretty straight forward, there were a couple actions that had their ignore_fullscreen_actions checks missed during our recent config changes. This just re-adds them to make that config value work a bit better.

7. 65c0159 Fix: #222 access denied saving grid
This was just fixing me being dumb trying to save the grid to a folder. When in debug mode it was trying to save to ./log rather than an actual file so I updated it to save to ./log/workspace.grid when running in debug mode. Release mode should be unaffected.

8. 86b7f83 Feat: added workspace_to_workspace nogscript binding
This adds a nogscript workspace function to move an entire workspace to another workspace as long as the target workspace is empty. I find this useful as it's easier for me to hit my main workspaces 1-4 while leaving the rest of the workspaces as "backburner" workspaces. I kept it at only working if the target is empty to avoid any weirdness caused by combining workspaces; I figure that'd be something much more complex and not user-friendly.

9. b076b3f Feat: updated deadlock logging to log all locked threads' backtraces
While working on all this I kept running into deadlocks and noticed that the deadlock detection just spits out the backtrace of one of the stacks that is locked. I updated this to show all threads that are deadlocked. Which helped me with...

**UPDATED BELOW Feb 03**

10.  d5f286a Fix: Prevent deadlocks when updating config values
While working on this pullrequest I kept running into deadlocks with the keybindings and I isolated them to two scenarios. This commit is just to prevent the deadlocks caused by the first scenario.

Both happen during hot-reloading. To re-create, try toggling the app_bar & taskbar repeatedly at random intervals.

Deadlock A (fixed in this commit):
hot_reload::update_config locks **state** and then calls KbManager.get_mode which attempts to lock "**inner**"

bottom loop of KbManager.start locks **inner** then tries to lock **state**

These two lock each other. I resolved this one by dropping the "inner" keyboard object in the bottom loop of KbManager once it's no longer needed.

Deadlock B (not fixed):
The other one is a little bit weirder but involves the [Windows SendMessageA function](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendmessagea). This happens when trying to close the app_bar; it calls SendMessageA on the app_bar window which "does not return until the window procedure has processed the message." Which, wouldn't be a big deal but...

What I've seen happen is that closing the app_bar locks the **state**, then it trigger this SendMessageA which fires off a window close event. Meanwhile, a separate thread is attempting to draw the app_bar and is attempting to lock the **state** repeatedly (WindowEvent::Draw in twm/src/bar/create.rs). So, it deadlocks with the **state** already locked in the SendMessageA call and the handler waiting on the Draw event to finish before handling the SendMessageA's close event and the Draw event waiting on the **state** to be unlocked. I was able to prevent this deadlock by using [PostMessageA](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-postmessagea) instead which queues the request rather than waiting on it.

Unfortunately, while using it throughout the day I noticed this introduced flashing artifact of the components in the app_bar and occasionally the app_bars would close. I'm not 100% sure why but once I reverted this portion of the commit those bugs disappeared. 

11. 44362f3 Feat: Updated documentation
Just updated the one doc line for workspace_to_workspace and removed a debug I left in.

12. cd413f5 Formatting
just running format on everything.
 

- [X] Add a move workspace to another workspace, i.e, moving all the tiles on workspace 3 to workspace 9
- [X] Re-add missing ignore_fullscreen_actions checks
- [X] Do something about #222 
