### PR TITLE
Added nightly flag to cargo build command

### DIFF
--- a/bin/make_release.ps1
+++ b/bin/make_release.ps1
@@ -8,7 +8,7 @@ $root_dir = "Nog"
 
 $env:NOG_VERSION=$Version
 
-cargo build --release -p twm
+cargo +nightly build --release -p twm
 
 if (!$?) {
   echo "Build was not successful. Aborting."


### PR DESCRIPTION
Since the Lua update hasn't been released yet a lot of people will probably be cloning and building nog, since we have a build script for this I think it's pointless to first run <<rustup override set nightly>> and then ./make_release.ps1.